### PR TITLE
Move dependencies to allow pypi upload

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,8 +14,5 @@ python:
     # Equivalent to 'pip install .'
     - method: pip
       path: .
-    # Equivalent to 'pip install .[docs]'
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+    # Equivalent to 'pip install -r docs/requirements.txt'
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+sphinx==4.5.0
+sphinx-copybutton==0.5.0
+sphinx-design==0.2.0
+pytorch_sphinx_theme @ git+https://github.com/liruilong940607/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+sphinx_copybutton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,15 +16,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# for documentation
-docs = [
-    "furo==2022.4.7",
-    "sphinx==4.5.0",
-    "sphinx-copybutton==0.5.0",
-    "sphinx-design==0.2.0",
-    "pytorch_sphinx_theme @ git+https://github.com/liruilong940607/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme",
-    "sphinx_copybutton"
-]
 
 # for development
 dev = [


### PR DESCRIPTION
Pypi doesn't allow git dependencies. A git dependency is used for the documentation. For now I have split the documentation requirements out of the pyproject.