### PR TITLE
Include pip package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nerfacc"
-version = "0.0.5"
+version = "0.0.6"
 authors = [{name = "Ruilong", email = "ruilongli94@gmail.com"}]
 license = { text="MIT" }
 requires-python = ">=3.8"
@@ -16,6 +16,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+
+[tool.setuptools.package-data]
+"*" = ["*.cu", "*.cpp", "*.h"]
 
 # for development
 dev = [


### PR DESCRIPTION
Pip package wasn't including C files causes it to crash when not installed in `-e` mode.