### PR TITLE
Added mark_invisible_cells_with_masks

### DIFF
--- a/nerfacc/estimators/occ_grid.py
+++ b/nerfacc/estimators/occ_grid.py
@@ -360,7 +360,7 @@ class OccGridEstimator(AbstractEstimator):
         assert K.shape[0] == c2w.shape[0] or K.shape[0] == 1
         assert masks is not None and len(masks) == c2w.shape[0]
         assert masks[0].dim() == 2
-        assert consensus_ratio > 1.0
+        assert consensus_ratio >= 1.0
 
         grid_res = self.resolution
         cells_per_lvl = self.cells_per_lvl
@@ -398,7 +398,7 @@ class OccGridEstimator(AbstractEstimator):
                 in_mask = in_mask.sum(0) >= (N_cams // consensus_ratio)
 
                 cell_ids_base = lvl * cells_per_lvl
-                occ_grid[cell_ids_base + indices_chunk] = torch.where(in_mask, 1.0, -1.0)
+                occ_grid[cell_ids_base + indices_chunk] = torch.where(in_mask, 0.0, -1.0)
 
         # Dilate all the not empty cells
         all_lvl_indices = [torch.arange(int(grid_res.prod().item()))]


### PR DESCRIPTION
Hello @liruilong940607.

I added the feature described in [VaxNeRF: Revisiting the Classic for Voxel-Accelerated Neural Radiance Field](https://arxiv.org/pdf/2111.13112.pdf).

Basically, I added a method to the `occ_grid` estimator to mark as empty the cells not covered by any mask (with a `consensus_ratio`), then apply a small dilation.
The implementation is similar to the already present `mark_invisible_cells`.

Even if the speed seems to not be concerned, this feature can help to avoid floaters in regions partially covered by the images.

If it seems a reasonable feature to you, please check it and tell me if it is necessary to change/improve the code.
Thanks you very much, and congratulations on the great work you made so far.