### PR TITLE
Fix distortion-loss to skip first term per sample / use inner zero sum

### DIFF
--- a/nerfacc/losses.py
+++ b/nerfacc/losses.py
@@ -1,6 +1,6 @@
 from torch import Tensor
 
-from .scan import inclusive_sum
+from .scan import exclusive_sum
 from .volrend import accumulate_along_rays
 
 
@@ -33,8 +33,8 @@ def distortion(
     t_mids = 0.5 * (t_starts + t_ends)
     t_deltas = t_ends - t_starts
     loss_uni = (1 / 3) * (t_deltas * weights.pow(2))
-    loss_bi_0 = weights * t_mids * inclusive_sum(weights, indices=ray_indices)
-    loss_bi_1 = weights * inclusive_sum(weights * t_mids, indices=ray_indices)
+    loss_bi_0 = weights * t_mids * exclusive_sum(weights, indices=ray_indices)
+    loss_bi_1 = weights * exclusive_sum(weights * t_mids, indices=ray_indices)
     loss_bi = 2 * (loss_bi_0 - loss_bi_1)
     loss = loss_uni + loss_bi
     loss = accumulate_along_rays(loss, None, ray_indices, n_rays)


### PR DESCRIPTION
Correctly evaluate Eq (2) of

Improved Direct Voxel Grid Optimization for Radiance Fields Reconstruction https://arxiv.org/pdf/2206.05085.pdf

----

The current formulation as an accumulation of per-sample terms requires the first term
to vanish and subsequent terms to be "matched" with an offset term of the scanned inner
sum, which is achieved using an exclusive scan.
