### PR TITLE
typo fixed: check packed_info rather than chunk_cnts

### DIFF
--- a/nerfacc/data_specs.py
+++ b/nerfacc/data_specs.py
@@ -54,7 +54,7 @@ class RaySamples:
         spec.vals = self.vals.contiguous()
         if self.packed_info is not None:
             spec.chunk_starts = self.packed_info[:, 0].contiguous()
-        if self.chunk_cnts is not None:
+        if self.packed_info is not None:
             spec.chunk_cnts = self.packed_info[:, 1].contiguous()
         if self.ray_indices is not None:
             spec.ray_indices = self.ray_indices.contiguous()


### PR DESCRIPTION
There is no member named ```chunk_cnts``` in the class RaySamples.
We should check ```self.packed_info is not None``` as we check it for assigning values to ```spec.chunk_starts```.

Before this fix, we cannot use the nerfacc.searchsorted using RaySamples with the following error message.
```AttributeError: 'RaySamples' object has no attribute 'chunk_cnts'```
After this fix, nerfacc.searchsorted works fine.